### PR TITLE
PORTABLE ファイルを実行ファイルと同じディレクトリに置くことで SQLite とログを実行ファイルと同じディレクトリで扱う

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,15 @@ macOS版はAppleによって公証されており、悪質なアプリケーシ�
 Windows版は証明書が高いため、コード署名を行っていません。起動時に警告が表示される場合があります。  
 Linux版はAppImage形式で提供しており、ほとんどのディストリビューションで動作します。
 
+## ポータブルモード
+
+実行ファイルと同じディレクトリに `PORTABLE` という名前のファイルがある場合、SQLiteのキャッシュDB `awayuki.db` とログファイル `awayuki.log` は実行ファイルと同じディレクトリから読み書きします。`PORTABLE` ファイルの中身は問いません。
+
+`PORTABLE` がない場合は、従来どおりOS標準のアプリケーションデータディレクトリを使用します。
+
+- Windows / Linux: `awayuki.exe` やAppImageなど、起動する実行ファイルと同じディレクトリに `PORTABLE` を置いてください。
+- macOS: `/Applications/PORTABLE` や `Awayuki.app` と同じディレクトリの `PORTABLE` は参照しません。
+
 ## ビルド
 
 ### macOS

--- a/src/state/paths.rs
+++ b/src/state/paths.rs
@@ -1,6 +1,8 @@
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use crate::constants::{APP_NAME, DB_FILENAME, LOG_FILENAME};
+
+const PORTABLE_MARKER_FILENAME: &str = "PORTABLE";
 
 /// Resolve the per-user data directory for awayuki.
 ///
@@ -29,9 +31,83 @@ pub fn data_dir() -> PathBuf {
 }
 
 pub fn db_path() -> PathBuf {
-    data_dir().join(DB_FILENAME)
+    app_storage_dir().join(DB_FILENAME)
 }
 
 pub fn log_file_path() -> PathBuf {
-    data_dir().join(LOG_FILENAME)
+    app_storage_dir().join(LOG_FILENAME)
+}
+
+fn app_storage_dir() -> PathBuf {
+    portable_data_dir().unwrap_or_else(data_dir)
+}
+
+fn portable_data_dir() -> Option<PathBuf> {
+    let executable = std::env::current_exe().ok()?;
+    portable_data_dir_for_executable(&executable)
+}
+
+fn portable_data_dir_for_executable(executable: &Path) -> Option<PathBuf> {
+    let executable_dir = executable.parent()?;
+    if executable_dir.join(PORTABLE_MARKER_FILENAME).is_file() {
+        Some(executable_dir.to_path_buf())
+    } else {
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn unique_temp_dir(name: &str) -> PathBuf {
+        let mut dir = std::env::temp_dir();
+        dir.push(format!("awayuki-paths-{}-{}", name, std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).expect("create temp dir");
+        dir
+    }
+
+    #[test]
+    fn portable_data_dir_uses_executable_dir_when_marker_exists() {
+        let dir = unique_temp_dir("portable");
+        let executable = dir.join("awayuki");
+        std::fs::write(dir.join(PORTABLE_MARKER_FILENAME), "").expect("write marker");
+
+        assert_eq!(
+            portable_data_dir_for_executable(&executable),
+            Some(dir.clone())
+        );
+
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn portable_data_dir_ignores_executable_dir_without_marker() {
+        let dir = unique_temp_dir("non-portable");
+        let executable = dir.join("awayuki");
+
+        assert_eq!(portable_data_dir_for_executable(&executable), None);
+
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn portable_data_dir_does_not_use_app_bundle_parent_marker() {
+        let dir = unique_temp_dir("macos-bundle-parent");
+        let app_parent = dir.join("Applications");
+        let executable_dir = app_parent
+            .join("Awayuki.app")
+            .join("Contents")
+            .join("MacOS");
+        std::fs::create_dir_all(&executable_dir).expect("create executable dir");
+        std::fs::write(app_parent.join(PORTABLE_MARKER_FILENAME), "").expect("write marker");
+
+        assert_eq!(
+            portable_data_dir_for_executable(&executable_dir.join("awayuki")),
+            None
+        );
+
+        let _ = std::fs::remove_dir_all(dir);
+    }
 }


### PR DESCRIPTION
## Summary
- `PORTABLE` ファイルが実行ファイルと同じディレクトリにある場合、SQLite の保存先を実行ファイル横に切り替えるようにしました。
- 同じ判定をログファイルにも適用し、`awayuki.log` もポータブル時は実行ファイル横に保存するようにしました。
- README にポータブルモードの挙動を追記しました。
- `src/state/paths.rs` に単体テストを追加し、`PORTABLE` の有無と macOS バンドル外ケースを検証しています。

## Testing
- `rustfmt --check src/state/paths.rs`
- `cargo test state::paths`
- `cargo fmt --check` は既存の `src/tauri_commands.rs` のフォーマット差分で失敗