### PR TITLE
Show post application data in posts with a Behavior setting

### DIFF
--- a/frontend/src/api/mock.ts
+++ b/frontend/src/api/mock.ts
@@ -427,6 +427,7 @@ const mockSnapshot: AppSnapshot = {
       confirm_follow: true,
       confirm_unfollow: true,
       jumbomoji_enabled: false,
+      show_status_application: false,
       media_source: "Local",
       translate_enabled: false,
       auto_translate_enabled: false,
@@ -536,6 +537,8 @@ function mockStatuses(
           : "<p>FF14 prep notes. This keeps the existing multi-column layout aligned with the Catppuccin palette.</p>",
       spoilerText: "",
       language: itemIndex % 3 === 0 ? "ja" : "en",
+      applicationName:
+        itemIndex % 2 === 0 ? "Twitter Web App" : "Awayuki Desktop",
       reblogsCount: itemIndex * 2,
       favouritesCount: itemIndex + 1,
       repliesCount: itemIndex % 4,

--- a/frontend/src/components/settings/SettingsView.tsx
+++ b/frontend/src/components/settings/SettingsView.tsx
@@ -132,6 +132,7 @@ const CUSTOM_TIMELINE_SCHEMA = [
       "bookmarked",
       "poll_json",
       "card_json",
+      "application_json",
       "mentions_json",
       "tags_json",
       "emojis_json",
@@ -195,6 +196,10 @@ const YQ_REFERENCE = [
       "visibility",
       "language",
       "lang",
+      "application",
+      "application_name",
+      "source",
+      "source_app",
       "spoiler_text",
       "cw",
       "sensitive",
@@ -689,6 +694,18 @@ function BehaviorSettingsPanel() {
           checked={settings.jumbomoji_enabled ?? false}
           onChange={(jumbomoji_enabled) => update({ jumbomoji_enabled })}
         />
+        <ToggleRow
+          label={t("Show post application")}
+          checked={settings.show_status_application ?? false}
+          onChange={(show_status_application) =>
+            update({ show_status_application })
+          }
+        />
+        <p className="col-span-2 text-xs text-subtext0">
+          {t(
+            "Due to Fediverse limitations, remote instances or servers may not provide post application data.",
+          )}
+        </p>
         <ToggleRow
           label={t("Translate posts")}
           checked={settings.translate_enabled}

--- a/frontend/src/components/timeline/TimelineArea.tsx
+++ b/frontend/src/components/timeline/TimelineArea.tsx
@@ -1225,6 +1225,10 @@ function StatusItem({
   const displayMode = useAppStore(
     (state) => state.snapshot?.settings.appearance.display_mode ?? "StarryEyes",
   );
+  const showStatusApplication = useAppStore(
+    (state) =>
+      state.snapshot?.settings.confirmation.show_status_application ?? false,
+  );
   const sourceBorderColor = useAppStore((state) =>
     accountSourceColorHex(
       status.sourceAcct
@@ -1245,6 +1249,9 @@ function StatusItem({
   } | null>(null);
   const url = statusUrl(status);
   const fontSizeClass = statusFontSizeClass(fontSize);
+  const statusApplicationLabel = showStatusApplication
+    ? status.applicationName?.trim()
+    : undefined;
   const isMystique = displayMode === "Mystique";
   const isCompact = isMystique && !mystiqueExpanded;
   const threadIndent = threadDepth > 0 ? 12 + threadDepth * 18 : undefined;
@@ -1350,11 +1357,16 @@ function StatusItem({
         </div>
         <button
           type="button"
-          className="shrink-0 text-xs text-overlay0 hover:text-blue"
+          className="inline-flex min-w-0 shrink-0 items-center gap-1 text-xs text-overlay0 hover:text-blue"
           onClick={openThread}
           title={t("Open thread")}
         >
           {formatTime(status.createdAt)}
+          {statusApplicationLabel ? (
+            <span className="hidden max-w-28 truncate sm:inline">
+              from {statusApplicationLabel}
+            </span>
+          ) : null}
         </button>
       </article>
     );
@@ -1403,6 +1415,11 @@ function StatusItem({
             >
               <VisibilityIcon visibility={status.visibility} />
               {formatTime(status.createdAt)}
+              {statusApplicationLabel ? (
+                <span className="max-w-36 truncate text-overlay0">
+                  from {statusApplicationLabel}
+                </span>
+              ) : null}
             </button>
           </div>
           <StatusContentBlock

--- a/frontend/src/i18n.ts
+++ b/frontend/src/i18n.ts
@@ -229,6 +229,9 @@ const ja: Record<string, string> = {
   Settings: "設定",
   "Single": "単一選択",
   "Show results": "結果を表示",
+  "Show post application": "投稿アプリを表示",
+  "Due to Fediverse limitations, remote instances or servers may not provide post application data.":
+    "Fediverse の制限により、リモートインスタンス/サーバーでは投稿アプリ情報が提供されず表示できない場合があります。",
   Sidecar: "サイドカー",
   "Add Sidecar": "サイドカーを追加",
   "Remove Sidecar": "サイドカーを削除",

--- a/frontend/src/types/app.ts
+++ b/frontend/src/types/app.ts
@@ -96,6 +96,7 @@ export type ConfirmationSettings = {
   confirm_follow: boolean;
   confirm_unfollow: boolean;
   jumbomoji_enabled?: boolean;
+  show_status_application?: boolean;
   media_source: "Local" | "Remote";
   translate_enabled: boolean;
   auto_translate_enabled: boolean;
@@ -295,6 +296,7 @@ export type TimelineStatus = {
   content: string;
   spoilerText: string;
   language?: string | null;
+  applicationName?: string | null;
   reblogsCount: number;
   favouritesCount: number;
   repliesCount: number;

--- a/migrations/003_create_statuses.sql
+++ b/migrations/003_create_statuses.sql
@@ -24,6 +24,7 @@ CREATE TABLE IF NOT EXISTS statuses (
     bookmarked INTEGER DEFAULT 0,
     poll_json TEXT,
     card_json TEXT,
+    application_json TEXT,
     mentions_json TEXT,
     tags_json TEXT,
     emojis_json TEXT,

--- a/migrations/019_add_status_application.sql
+++ b/migrations/019_add_status_application.sql
@@ -1,0 +1,1 @@
+ALTER TABLE statuses ADD COLUMN application_json TEXT;

--- a/src/db/models.rs
+++ b/src/db/models.rs
@@ -62,6 +62,7 @@ pub struct DbStatus {
     pub bookmarked: Option<bool>,
     pub poll_json: Option<String>,
     pub card_json: Option<String>,
+    pub application_json: Option<String>,
     pub mentions_json: Option<String>,
     pub tags_json: Option<String>,
     pub emojis_json: Option<String>,
@@ -192,6 +193,10 @@ impl DbStatus {
                 .card
                 .as_ref()
                 .and_then(|c| serde_json::to_string(c).ok()),
+            application_json: status
+                .application
+                .as_ref()
+                .and_then(|application| serde_json::to_string(application).ok()),
             mentions_json: if status.mentions.is_empty() {
                 None
             } else {

--- a/src/db/pool.rs
+++ b/src/db/pool.rs
@@ -75,6 +75,7 @@ impl Database {
             include_str!("../../migrations/015_add_app_password.sql"),
             include_str!("../../migrations/017_add_notification_account_acct.sql"),
             include_str!("../../migrations/018_add_timeline_query_indexes.sql"),
+            include_str!("../../migrations/019_add_status_application.sql"),
         ];
 
         for sql in &alter_migrations {

--- a/src/db/queries/statuses.rs
+++ b/src/db/queries/statuses.rs
@@ -4,8 +4,8 @@ use crate::db::models::DbStatus;
 
 pub async fn upsert_status(pool: &SqlitePool, status: &DbStatus) -> Result<(), sqlx::Error> {
     sqlx::query(
-        "INSERT INTO statuses (id, server_domain, uri, url, created_at, edited_at, account_id, content, visibility, sensitive, spoiler_text, reblogs_count, favourites_count, replies_count, in_reply_to_id, in_reply_to_account_id, reblog_of_id, language, pinned, favourited, reblogged, muted, bookmarked, poll_json, card_json, mentions_json, tags_json, emojis_json, media_attachments_json, fetched_at, quote_id, quote_original_url)
-         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        "INSERT INTO statuses (id, server_domain, uri, url, created_at, edited_at, account_id, content, visibility, sensitive, spoiler_text, reblogs_count, favourites_count, replies_count, in_reply_to_id, in_reply_to_account_id, reblog_of_id, language, pinned, favourited, reblogged, muted, bookmarked, poll_json, card_json, application_json, mentions_json, tags_json, emojis_json, media_attachments_json, fetched_at, quote_id, quote_original_url)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
          ON CONFLICT(id, server_domain) DO UPDATE SET
            uri = excluded.uri,
            url = excluded.url,
@@ -28,6 +28,7 @@ pub async fn upsert_status(pool: &SqlitePool, status: &DbStatus) -> Result<(), s
            bookmarked = excluded.bookmarked,
            poll_json = excluded.poll_json,
            card_json = excluded.card_json,
+           application_json = excluded.application_json,
            mentions_json = excluded.mentions_json,
            tags_json = excluded.tags_json,
            emojis_json = excluded.emojis_json,
@@ -61,6 +62,7 @@ pub async fn upsert_status(pool: &SqlitePool, status: &DbStatus) -> Result<(), s
     .bind(status.bookmarked)
     .bind(&status.poll_json)
     .bind(&status.card_json)
+    .bind(&status.application_json)
     .bind(&status.mentions_json)
     .bind(&status.tags_json)
     .bind(&status.emojis_json)

--- a/src/services/yq_filter.rs
+++ b/src/services/yq_filter.rs
@@ -60,6 +60,17 @@ fn opt_str_to_expr(s: &Option<String>) -> Expression {
     }
 }
 
+fn status_application_name(status: &DbStatus) -> Option<String> {
+    status
+        .application_json
+        .as_deref()
+        .and_then(|json| {
+            serde_json::from_str::<crate::mastodon::types::status::StatusApplication>(json).ok()
+        })
+        .map(|application| application.name.trim().to_string())
+        .filter(|name| !name.is_empty())
+}
+
 impl VariableProvider for MastodonVariableProvider {
     fn get(&self, symbol: &str) -> Option<Expression> {
         match symbol {
@@ -70,6 +81,9 @@ impl VariableProvider for MastodonVariableProvider {
                 self.status.visibility.clone(),
             ))),
             "language" | "lang" => Some(opt_str_to_expr(&self.status.language)),
+            "application" | "application_name" | "source" | "source_app" => {
+                Some(opt_str_to_expr(&status_application_name(&self.status)))
+            }
             "spoiler_text" | "cw" => {
                 if self.status.spoiler_text.is_empty() {
                     Some(Expression::nil())

--- a/src/state/confirmation.rs
+++ b/src/state/confirmation.rs
@@ -34,6 +34,8 @@ pub struct ConfirmationSettings {
     #[serde(default)]
     pub jumbomoji_enabled: bool,
     #[serde(default)]
+    pub show_status_application: bool,
+    #[serde(default)]
     pub media_source: MediaSource,
     #[serde(default)]
     pub translate_enabled: bool,
@@ -51,6 +53,7 @@ impl Default for ConfirmationSettings {
             confirm_follow: true,
             confirm_unfollow: true,
             jumbomoji_enabled: false,
+            show_status_application: false,
             media_source: MediaSource::Local,
             translate_enabled: false,
             auto_translate_enabled: false,

--- a/src/tauri_commands.rs
+++ b/src/tauri_commands.rs
@@ -41,7 +41,7 @@ use crate::mastodon::oauth::OAuthFlow;
 use crate::mastodon::types::account::Account;
 use crate::mastodon::types::instance::Instance;
 use crate::mastodon::types::notification::{Notification, NotificationType};
-use crate::mastodon::types::status::{MediaAttachment, Poll, Status};
+use crate::mastodon::types::status::{MediaAttachment, Poll, Status, StatusApplication};
 use crate::misskey::auth::MiAuthFlow;
 use crate::misskey::client::MisskeyClient;
 use crate::services::streaming_service::{self, TimelineEvent};
@@ -741,6 +741,7 @@ struct TimelineStatus {
     content: String,
     spoiler_text: String,
     language: Option<String>,
+    application_name: Option<String>,
     reblogs_count: i64,
     favourites_count: i64,
     replies_count: i64,
@@ -4337,11 +4338,7 @@ async fn sync_all_favourites(
 
         let count = response.data.len();
         for status in response.data {
-            let mut favourite_status = status
-                .reblog
-                .as_deref()
-                .cloned()
-                .unwrap_or(status);
+            let mut favourite_status = status.reblog.as_deref().cloned().unwrap_or(status);
             favourite_status.favourited = Some(true);
             let position_at = favourite_status.created_at.to_rfc3339();
             timeline_service::save_status_to_db_with_retry(
@@ -6252,6 +6249,7 @@ fn db_status_to_view(status: DbStatus, account: Option<DbAccount>) -> TimelineSt
         content: status.content,
         spoiler_text: status.spoiler_text,
         language: status.language,
+        application_name: application_name_from_json(status.application_json.as_deref()),
         reblogs_count: status.reblogs_count,
         favourites_count: status.favourites_count,
         replies_count: status.replies_count,
@@ -6274,6 +6272,27 @@ fn db_status_to_view(status: DbStatus, account: Option<DbAccount>) -> TimelineSt
         notification_acct: None,
         notification_display_name: None,
         notification_account_emojis: Vec::new(),
+    }
+}
+
+fn application_name_from_json(json: Option<&str>) -> Option<String> {
+    json.and_then(|json| serde_json::from_str::<StatusApplication>(json).ok())
+        .and_then(|application| normalized_application_name(&application.name))
+}
+
+fn status_application_name(status: &Status) -> Option<String> {
+    status
+        .application
+        .as_ref()
+        .and_then(|application| normalized_application_name(&application.name))
+}
+
+fn normalized_application_name(name: &str) -> Option<String> {
+    let name = name.trim();
+    if name.is_empty() {
+        None
+    } else {
+        Some(name.to_string())
     }
 }
 
@@ -6413,6 +6432,7 @@ fn status_to_view_base_with_quote_depth(
         content: status.content.clone(),
         spoiler_text: status.spoiler_text.clone(),
         language: status.language.clone(),
+        application_name: status_application_name(status),
         reblogs_count: status.reblogs_count,
         favourites_count: status.favourites_count,
         replies_count: status.replies_count,
@@ -6509,6 +6529,7 @@ fn notification_db_to_view(
                 content: String::new(),
                 spoiler_text: String::new(),
                 language: None,
+                application_name: None,
                 reblogs_count: 0,
                 favourites_count: 0,
                 replies_count: 0,
@@ -6570,6 +6591,7 @@ fn notification_to_view(
             content: String::new(),
             spoiler_text: String::new(),
             language: None,
+            application_name: None,
             reblogs_count: 0,
             favourites_count: 0,
             replies_count: 0,
@@ -6796,6 +6818,7 @@ mod tests {
             bookmarked: None,
             poll_json: None,
             card_json: None,
+            application_json: None,
             mentions_json: None,
             tags_json: None,
             emojis_json: None,


### PR DESCRIPTION
## Summary
- Add a `Show post application` toggle under Settings > Behavior, defaulting to off
- Persist status application data in the database and surface it in timeline views when enabled
- Expose application fields to YQ filters and add a note that remote Fediverse instances may not provide this data

## Testing
- `bun run build`
- `bunx tsc --noEmit --ignoreDeprecations 5.0`
- `cargo check`
- `cargo test yq -- --nocapture`
- `cargo fmt --check`
- `git diff --check`