### PR TITLE
Windows版のアプリタイトルをAwayukiに設定する

### DIFF
--- a/tauri.windows.conf.json
+++ b/tauri.windows.conf.json
@@ -4,7 +4,14 @@
     "withGlobalTauri": true,
     "windows": [
       {
-        "decorations": false
+        "title": "Awayuki",
+        "width": 1200,
+        "height": 800,
+        "minWidth": 520,
+        "minHeight": 640,
+        "decorations": false,
+        "transparent": false,
+        "devtools": true
       }
     ]
   }

--- a/tauri.windows.conf.json
+++ b/tauri.windows.conf.json
@@ -5,12 +5,7 @@
     "windows": [
       {
         "title": "Awayuki",
-        "width": 1200,
-        "height": 800,
-        "minWidth": 520,
-        "minHeight": 640,
         "decorations": false,
-        "transparent": false,
         "devtools": true
       }
     ]


### PR DESCRIPTION
## Summary
- `tauri.windows.conf.json` のウィンドウ設定をベース設定と揃え、Windows でも `Awayuki` をタイトルに明示
- サイズと `transparent` / `devtools` も明示して、Windows 用設定でタイトルが既定値に戻らないように修正

## Testing
- Not run (not requested)