### PR TITLE
日本語の AIR context ラベルを翻訳する

### DIFF
--- a/frontend/src/i18n.ts
+++ b/frontend/src/i18n.ts
@@ -110,7 +110,7 @@ const ja: Record<string, string> = {
   "Fetch": "取得",
   "Fetch lists": "リストを取得",
   "Fetching lists": "リストを取得中",
-  "Find AIR context": "Find AIR context",
+  "Find AIR context": "空中コンテキストを検索",
   "File logging": "ファイルログ",
   Flags: "旗",
   "Follow": "フォロー",


### PR DESCRIPTION
## Summary
- 日本語リソースの `Find AIR context` を `空中コンテキストを検索` に変更
- 英語リソースは変更なし

## Testing
- Not run (not requested)