### PR TITLE
カスタム絵文字の最大幅を100%に変更する

### DIFF
--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -211,7 +211,7 @@ textarea {
     display: inline-block;
     width: auto;
     height: 1.25em;
-    max-width: 2.5em;
+    max-width: 100%;
     object-fit: contain;
     vertical-align: -0.25em;
 }
@@ -221,7 +221,7 @@ textarea {
 .status-content-jumbomoji img.emojione,
 .status-content-jumbomoji img.custom-emoji {
     height: 1em;
-    max-width: 2em;
+    max-width: 100%;
     vertical-align: -0.1em;
 }
 


### PR DESCRIPTION
## Summary
- カスタム絵文字の `max-width` を `100%` に変更
- 通常表示と Jumbomoji 表示の両方で横長画像が潰れないように調整

## Testing
- Not run (not requested)