### PR TITLE
quote_id based quote 展開を streaming まで反映する

### DIFF
--- a/src/services/streaming_service.rs
+++ b/src/services/streaming_service.rs
@@ -98,12 +98,18 @@ pub fn start_streaming(
         let domain = server_domain.clone();
         let acct = source_acct.clone();
         let txs = event_txs.clone();
+        let lookup_client = client.clone();
         let handle = tokio::spawn(async move {
             while let Some(event) = ws_rx.recv().await {
                 match event {
                     StreamEvent::Update(payload) => {
                         match serde_json::from_str::<Status>(&payload) {
-                            Ok(status) => {
+                            Ok(mut status) => {
+                                timeline_service::hydrate_missing_quotes(
+                                    &lookup_client,
+                                    std::slice::from_mut(&mut status),
+                                )
+                                .await;
                                 if let Err(e) = timeline_service::save_status_to_db_with_retry(
                                     db.writer(),
                                     &status,
@@ -150,7 +156,12 @@ pub fn start_streaming(
                     }
                     StreamEvent::StatusUpdate(payload) => {
                         match serde_json::from_str::<Status>(&payload) {
-                            Ok(status) => {
+                            Ok(mut status) => {
+                                timeline_service::hydrate_missing_quotes(
+                                    &lookup_client,
+                                    std::slice::from_mut(&mut status),
+                                )
+                                .await;
                                 if let Err(e) = timeline_service::save_status_to_db_with_retry(
                                     db.writer(),
                                     &status,
@@ -209,7 +220,14 @@ pub fn start_streaming(
                     }
                     StreamEvent::Notification(payload) => {
                         match serde_json::from_str::<Notification>(&payload) {
-                            Ok(notification) => {
+                            Ok(mut notification) => {
+                                if let Some(status) = notification.status.as_mut() {
+                                    timeline_service::hydrate_missing_quotes(
+                                        &lookup_client,
+                                        std::slice::from_mut(status),
+                                    )
+                                    .await;
+                                }
                                 let event = TimelineEvent::NewNotification(
                                     notification,
                                     stream_type.clone(),

--- a/src/services/streaming_service.rs
+++ b/src/services/streaming_service.rs
@@ -105,7 +105,7 @@ pub fn start_streaming(
                     StreamEvent::Update(payload) => {
                         match serde_json::from_str::<Status>(&payload) {
                             Ok(mut status) => {
-                                timeline_service::hydrate_missing_quotes(
+                                timeline_service::hydrate_and_resolve_quotes(
                                     &lookup_client,
                                     std::slice::from_mut(&mut status),
                                 )
@@ -157,7 +157,7 @@ pub fn start_streaming(
                     StreamEvent::StatusUpdate(payload) => {
                         match serde_json::from_str::<Status>(&payload) {
                             Ok(mut status) => {
-                                timeline_service::hydrate_missing_quotes(
+                                timeline_service::hydrate_and_resolve_quotes(
                                     &lookup_client,
                                     std::slice::from_mut(&mut status),
                                 )
@@ -222,7 +222,7 @@ pub fn start_streaming(
                         match serde_json::from_str::<Notification>(&payload) {
                             Ok(mut notification) => {
                                 if let Some(status) = notification.status.as_mut() {
-                                    timeline_service::hydrate_missing_quotes(
+                                    timeline_service::hydrate_and_resolve_quotes(
                                         &lookup_client,
                                         std::slice::from_mut(status),
                                     )

--- a/src/services/streaming_service.rs
+++ b/src/services/streaming_service.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 use std::time::Duration;
 
+use futures::StreamExt;
 use tokio::sync::mpsc;
 
 use crate::api::client::ApiClient;
@@ -27,6 +28,93 @@ pub enum TimelineEvent {
     StatusUpdate(Status, String, String),
     DeleteStatus(String, String, String),
     NewNotification(Notification, StreamType, String, String),
+}
+
+/// Maximum number of streaming events whose quote hydration (network I/O)
+/// may run concurrently ahead of the sequential persist/broadcast stage.
+const QUOTE_HYDRATION_CONCURRENCY: usize = 8;
+
+/// Upper bound on the time spent hydrating quotes for a single streaming
+/// event, so a slow quote lookup can't stall the pipeline indefinitely.
+const QUOTE_HYDRATION_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// A stream event after parsing and quote hydration, ready for the
+/// sequential persist/broadcast stage.
+enum ProcessedEvent {
+    Update(Status),
+    StatusUpdate(Status),
+    Delete(String),
+    Notification(Notification),
+}
+
+/// Parse a raw stream event and hydrate quotes (network I/O). Returns `None`
+/// for events that need no further processing (parse failures, unknown
+/// events, filter changes).
+async fn preprocess_stream_event(
+    client: &ApiClient,
+    event: StreamEvent,
+) -> Option<ProcessedEvent> {
+    match event {
+        StreamEvent::Update(payload) => match serde_json::from_str::<Status>(&payload) {
+            Ok(mut status) => {
+                hydrate_quotes_with_timeout(client, &mut status).await;
+                Some(ProcessedEvent::Update(status))
+            }
+            Err(e) => {
+                tracing::warn!("Failed to parse streaming status: {}", e);
+                None
+            }
+        },
+        StreamEvent::StatusUpdate(payload) => match serde_json::from_str::<Status>(&payload) {
+            Ok(mut status) => {
+                hydrate_quotes_with_timeout(client, &mut status).await;
+                Some(ProcessedEvent::StatusUpdate(status))
+            }
+            Err(e) => {
+                tracing::warn!("Failed to parse streaming status update: {}", e);
+                None
+            }
+        },
+        StreamEvent::Delete(id) => Some(ProcessedEvent::Delete(id)),
+        StreamEvent::Notification(payload) => {
+            match serde_json::from_str::<Notification>(&payload) {
+                Ok(mut notification) => {
+                    if let Some(status) = notification.status.as_mut() {
+                        hydrate_quotes_with_timeout(client, status).await;
+                    }
+                    Some(ProcessedEvent::Notification(notification))
+                }
+                Err(e) => {
+                    tracing::warn!("Failed to parse streaming notification: {}", e);
+                    None
+                }
+            }
+        }
+        StreamEvent::FiltersChanged => {
+            // TODO: Handle filter changes
+            None
+        }
+        StreamEvent::Unknown(event, _payload) => {
+            tracing::debug!("Ignoring unknown stream event: {}", event);
+            None
+        }
+    }
+}
+
+async fn hydrate_quotes_with_timeout(client: &ApiClient, status: &mut Status) {
+    if tokio::time::timeout(
+        QUOTE_HYDRATION_TIMEOUT,
+        timeline_service::hydrate_and_resolve_quotes(client, std::slice::from_mut(status)),
+    )
+    .await
+    .is_err()
+    {
+        tracing::warn!(
+            "Timed out hydrating quotes for streaming status {} on {}",
+            status.id,
+            client.domain()
+        );
+    }
 }
 
 /// Start streaming connections for multiple stream types and forward timeline events to the given sender.
@@ -57,7 +145,7 @@ pub fn start_streaming(
     let mut abort_handles = Vec::new();
 
     for stream_type in stream_types {
-        let (ws_tx, mut ws_rx) = mpsc::unbounded_channel::<StreamEvent>();
+        let (ws_tx, ws_rx) = mpsc::unbounded_channel::<StreamEvent>();
 
         // Spawn the WebSocket connection (runs forever with reconnection)
         let url = streaming_url.clone();
@@ -94,103 +182,82 @@ pub fn start_streaming(
         abort_handles.push(handle.abort_handle());
 
         // Spawn the event processor (tokio side: parse, persist, broadcast).
+        //
+        // Parsing and quote hydration (network I/O) run concurrently for up to
+        // `QUOTE_HYDRATION_CONCURRENCY` events via an order-preserving
+        // `buffered` stage, so slow quote lookups don't stall draining the
+        // unbounded channel. The sequential stage below only does DB writes
+        // and broadcasting.
         let db = database.clone();
         let domain = server_domain.clone();
         let acct = source_acct.clone();
         let txs = event_txs.clone();
         let lookup_client = client.clone();
         let handle = tokio::spawn(async move {
-            while let Some(event) = ws_rx.recv().await {
-                match event {
-                    StreamEvent::Update(payload) => {
-                        match serde_json::from_str::<Status>(&payload) {
-                            Ok(mut status) => {
-                                timeline_service::hydrate_and_resolve_quotes(
-                                    &lookup_client,
-                                    std::slice::from_mut(&mut status),
-                                )
-                                .await;
-                                if let Err(e) = timeline_service::save_status_to_db_with_retry(
-                                    db.writer(),
-                                    &status,
-                                    &domain,
-                                )
-                                .await
-                                {
-                                    tracing::warn!("Failed to save streaming status to DB: {}", e);
-                                }
-                                if let Some(timeline_key) =
-                                    timeline_key_for_stream_type(&stream_type)
-                                {
-                                    if let Err(e) =
-                                        timeline_service::insert_timeline_entry_with_retry(
-                                            db.writer(),
-                                            &timeline_key,
-                                            &domain,
-                                            &status.id,
-                                            &acct,
-                                            &status.created_at.to_rfc3339(),
-                                        )
-                                        .await
-                                    {
-                                        tracing::warn!(
-                                            "Failed to save streaming timeline entry: {}",
-                                            e
-                                        );
-                                    }
-                                }
-                                let event = TimelineEvent::NewStatus(
-                                    status,
-                                    stream_type.clone(),
-                                    acct.clone(),
-                                    domain.clone(),
-                                );
-                                if !broadcast_event(&txs, event) {
-                                    return;
-                                }
-                            }
-                            Err(e) => {
-                                tracing::warn!("Failed to parse streaming status: {}", e);
+            let events = futures::stream::unfold(ws_rx, |mut rx| async move {
+                rx.recv().await.map(|event| (event, rx))
+            });
+            let processed_events = events
+                .map(|event| {
+                    let client = lookup_client.clone();
+                    async move { preprocess_stream_event(&client, event).await }
+                })
+                .buffered(QUOTE_HYDRATION_CONCURRENCY);
+            futures::pin_mut!(processed_events);
+            while let Some(processed) = processed_events.next().await {
+                match processed {
+                    Some(ProcessedEvent::Update(status)) => {
+                        if let Err(e) = timeline_service::save_status_to_db_with_retry(
+                            db.writer(),
+                            &status,
+                            &domain,
+                        )
+                        .await
+                        {
+                            tracing::warn!("Failed to save streaming status to DB: {}", e);
+                        }
+                        if let Some(timeline_key) = timeline_key_for_stream_type(&stream_type) {
+                            if let Err(e) = timeline_service::insert_timeline_entry_with_retry(
+                                db.writer(),
+                                &timeline_key,
+                                &domain,
+                                &status.id,
+                                &acct,
+                                &status.created_at.to_rfc3339(),
+                            )
+                            .await
+                            {
+                                tracing::warn!("Failed to save streaming timeline entry: {}", e);
                             }
                         }
-                    }
-                    StreamEvent::StatusUpdate(payload) => {
-                        match serde_json::from_str::<Status>(&payload) {
-                            Ok(mut status) => {
-                                timeline_service::hydrate_and_resolve_quotes(
-                                    &lookup_client,
-                                    std::slice::from_mut(&mut status),
-                                )
-                                .await;
-                                if let Err(e) = timeline_service::save_status_to_db_with_retry(
-                                    db.writer(),
-                                    &status,
-                                    &domain,
-                                )
-                                .await
-                                {
-                                    tracing::warn!(
-                                        "Failed to save streaming status update to DB: {}",
-                                        e
-                                    );
-                                }
-                                if !broadcast_event(
-                                    &txs,
-                                    TimelineEvent::StatusUpdate(
-                                        status,
-                                        acct.clone(),
-                                        domain.clone(),
-                                    ),
-                                ) {
-                                    return;
-                                }
-                            }
-                            Err(e) => {
-                                tracing::warn!("Failed to parse streaming status update: {}", e);
-                            }
+                        let event = TimelineEvent::NewStatus(
+                            status,
+                            stream_type.clone(),
+                            acct.clone(),
+                            domain.clone(),
+                        );
+                        if !broadcast_event(&txs, event) {
+                            return;
                         }
                     }
-                    StreamEvent::Delete(id) => {
+                    Some(ProcessedEvent::StatusUpdate(status)) => {
+                        if let Err(e) = timeline_service::save_status_to_db_with_retry(
+                            db.writer(),
+                            &status,
+                            &domain,
+                        )
+                        .await
+                        {
+                            tracing::warn!("Failed to save streaming status update to DB: {}", e);
+                        }
+                        if !broadcast_event(
+                            &txs,
+                            TimelineEvent::StatusUpdate(status, acct.clone(), domain.clone()),
+                        ) {
+                            return;
+                        }
+                    }
+                    Some(ProcessedEvent::Delete(id)) => {
                         match timeline_service::delete_status_from_db_with_retry(
                             db.writer(),
                             &id,
@@ -218,37 +285,18 @@ pub fn start_streaming(
                             return;
                         }
                     }
-                    StreamEvent::Notification(payload) => {
-                        match serde_json::from_str::<Notification>(&payload) {
-                            Ok(mut notification) => {
-                                if let Some(status) = notification.status.as_mut() {
-                                    timeline_service::hydrate_and_resolve_quotes(
-                                        &lookup_client,
-                                        std::slice::from_mut(status),
-                                    )
-                                    .await;
-                                }
-                                let event = TimelineEvent::NewNotification(
-                                    notification,
-                                    stream_type.clone(),
-                                    acct.clone(),
-                                    domain.clone(),
-                                );
-                                if !broadcast_event(&txs, event) {
-                                    return;
-                                }
-                            }
-                            Err(e) => {
-                                tracing::warn!("Failed to parse streaming notification: {}", e);
-                            }
+                    Some(ProcessedEvent::Notification(notification)) => {
+                        let event = TimelineEvent::NewNotification(
+                            notification,
+                            stream_type.clone(),
+                            acct.clone(),
+                            domain.clone(),
+                        );
+                        if !broadcast_event(&txs, event) {
+                            return;
                         }
                     }
-                    StreamEvent::FiltersChanged => {
-                        // TODO: Handle filter changes
-                    }
-                    StreamEvent::Unknown(event, _payload) => {
-                        tracing::debug!("Ignoring unknown stream event: {}", event);
-                    }
+                    None => {}
                 }
             }
         });

--- a/src/services/timeline_service.rs
+++ b/src/services/timeline_service.rs
@@ -369,15 +369,16 @@ async fn resolve_linked_quotes_once(client: &ApiClient, statuses: &mut [Status],
         if status.quote.is_some() {
             continue;
         }
-        if !content_contains_quote_reply_marker(&status.content) {
-            continue;
-        }
 
-        let Some(quote_url) = status
-            .quote_original_url
-            .clone()
-            .or_else(|| extract_status_link(&status.content))
-        else {
+        let quote_url = if let Some(url) = status.quote_original_url.clone() {
+            Some(url)
+        } else if content_contains_quote_reply_marker(&status.content) {
+            extract_status_link(&status.content)
+        } else {
+            None
+        };
+
+        let Some(quote_url) = quote_url else {
             continue;
         };
 

--- a/src/services/timeline_service.rs
+++ b/src/services/timeline_service.rs
@@ -308,6 +308,11 @@ pub async fn hydrate_missing_quotes(client: &ApiClient, statuses: &mut [Status])
     hydrate_missing_quotes_once(client, statuses, true).await;
 }
 
+pub async fn hydrate_and_resolve_quotes(client: &ApiClient, statuses: &mut [Status]) {
+    hydrate_missing_quotes_once(client, statuses, true).await;
+    resolve_linked_quotes_once(client, statuses, true).await;
+}
+
 pub async fn resolve_pending_quotes_with_backoff(client: &ApiClient, statuses: &mut [Status]) {
     hydrate_missing_quotes_once(client, statuses, true).await;
     resolve_linked_quotes_once(client, statuses, true).await;

--- a/src/services/timeline_service.rs
+++ b/src/services/timeline_service.rs
@@ -1,7 +1,12 @@
-use std::time::{Duration, Instant};
+use std::{
+    sync::OnceLock,
+    time::{Duration, Instant},
+};
 
 use chrono::Utc;
+use regex::Regex;
 use sqlx::SqlitePool;
+use url::Url;
 
 use crate::api::client::ApiClient;
 use crate::api::kind::ServerKind;
@@ -305,6 +310,7 @@ pub async fn hydrate_missing_quotes(client: &ApiClient, statuses: &mut [Status])
 
 pub async fn resolve_pending_quotes_with_backoff(client: &ApiClient, statuses: &mut [Status]) {
     hydrate_missing_quotes_once(client, statuses, true).await;
+    resolve_linked_quotes_once(client, statuses, true).await;
 
     let mut unresolved = unresolved_quote_candidate_count(client.kind(), statuses);
     if unresolved == 0 {
@@ -329,6 +335,12 @@ pub async fn resolve_pending_quotes_with_backoff(client: &ApiClient, statuses: &
             attempt + 1 == QUOTE_RESOLUTION_RETRY_DELAYS_MS.len(),
         )
         .await;
+        resolve_linked_quotes_once(
+            client,
+            statuses,
+            attempt + 1 == QUOTE_RESOLUTION_RETRY_DELAYS_MS.len(),
+        )
+        .await;
 
         unresolved = unresolved_quote_candidate_count(client.kind(), statuses);
         if unresolved == 0 {
@@ -346,6 +358,70 @@ pub async fn resolve_pending_quotes_with_backoff(client: &ApiClient, statuses: &
         unresolved,
         client.domain()
     );
+}
+
+async fn resolve_linked_quotes_once(client: &ApiClient, statuses: &mut [Status], warn: bool) {
+    if !client.kind().is_mastodon_compatible() {
+        return;
+    }
+
+    for status in statuses {
+        if status.quote.is_some() {
+            continue;
+        }
+        if !content_contains_quote_reply_marker(&status.content) {
+            continue;
+        }
+
+        let Some(quote_url) = status
+            .quote_original_url
+            .clone()
+            .or_else(|| extract_status_link(&status.content))
+        else {
+            continue;
+        };
+
+        match client.lookup_status_by_uri(&quote_url).await {
+            Ok(Some(quote)) => {
+                if quote.id == status.id {
+                    tracing::debug!(
+                        "Resolved quote URL {} to the source status {} on {}; ignoring",
+                        quote_url,
+                        status.id,
+                        client.domain()
+                    );
+                    continue;
+                }
+                status.quote_id = Some(quote.id.clone());
+                status.quote_original_url = Some(quote_url);
+                status.quote = Some(Box::new(quote));
+            }
+            Ok(None) => {
+                tracing::debug!(
+                    "Quote URL {} did not resolve to a status on {}",
+                    quote_url,
+                    client.domain()
+                );
+            }
+            Err(error) => {
+                if warn {
+                    tracing::warn!(
+                        "Failed to resolve quote URL {} on {}: {}",
+                        quote_url,
+                        client.domain(),
+                        error
+                    );
+                } else {
+                    tracing::debug!(
+                        "Quote URL {} is not ready on {}: {}",
+                        quote_url,
+                        client.domain(),
+                        error
+                    );
+                }
+            }
+        }
+    }
 }
 
 async fn hydrate_missing_quotes_once(client: &ApiClient, statuses: &mut [Status], warn: bool) {
@@ -432,12 +508,46 @@ fn is_recent_enough_for_quote_resolution(status: &Status) -> bool {
 }
 
 fn content_contains_status_link(content: &str) -> bool {
-    content.contains("href=\"")
-        && (content.contains("/@") || content.contains("/users/"))
-        && (content.contains("rel=\"nofollow")
-            || content.contains("class=\"u-url")
-            || content.contains("class=\"status-link")
-            || content.contains("/statuses/"))
+    extract_status_link(content).is_some()
+}
+
+fn extract_status_link(content: &str) -> Option<String> {
+    status_link_href_regex()
+        .captures_iter(content)
+        .filter_map(|capture| capture.get(1).map(|href| html_unescape_href(href.as_str())))
+        .find(|href| is_probable_status_url(href))
+}
+
+fn status_link_href_regex() -> &'static Regex {
+    static HREF_RE: OnceLock<Regex> = OnceLock::new();
+    HREF_RE.get_or_init(|| Regex::new(r#"href\s*=\s*["']([^"']+)["']"#).expect("valid href regex"))
+}
+
+fn html_unescape_href(href: &str) -> String {
+    href.replace("&amp;", "&")
+        .replace("&quot;", "\"")
+        .replace("&#39;", "'")
+        .replace("&#x27;", "'")
+}
+
+fn is_probable_status_url(href: &str) -> bool {
+    let Ok(url) = Url::parse(href) else {
+        return false;
+    };
+    let path = url.path();
+
+    is_mastodon_status_path(path) || is_misskey_note_path(path)
+}
+
+fn is_mastodon_status_path(path: &str) -> bool {
+    (path.starts_with("/@") && path.trim_matches('/').split('/').count() >= 2)
+        || (path.starts_with("/users/") && path.contains("/statuses/"))
+        || path.contains("/statuses/")
+}
+
+fn is_misskey_note_path(path: &str) -> bool {
+    path.strip_prefix("/notes/")
+        .is_some_and(|note_id| !note_id.trim_matches('/').is_empty())
 }
 
 fn content_contains_quote_reply_marker(content: &str) -> bool {
@@ -657,6 +767,28 @@ mod tests {
 
         assert!(content_contains_status_link(content));
         assert!(content_contains_quote_reply_marker(content));
+    }
+
+    #[test]
+    fn detects_misskey_note_links_as_pending_quote_candidates() {
+        let content = r#"<p>RE:<br><a href="https://azkey.azuki.blue/notes/ancxkus54yvf1jqf" rel="nofollow noopener noreferrer" target="_blank">azkey.azuki.blue/notes/ancxkus54yvf1jqf</a></p>"#;
+
+        assert!(content_contains_status_link(content));
+        assert_eq!(
+            extract_status_link(content).as_deref(),
+            Some("https://azkey.azuki.blue/notes/ancxkus54yvf1jqf")
+        );
+        assert!(content_contains_quote_reply_marker(content));
+    }
+
+    #[test]
+    fn unescapes_status_link_hrefs() {
+        let content = r#"<p>RE:<br><a href="https://mastodon.example/@alice/123?foo=1&amp;bar=2">mastodon.example/@alice/123</a></p>"#;
+
+        assert_eq!(
+            extract_status_link(content).as_deref(),
+            Some("https://mastodon.example/@alice/123?foo=1&bar=2")
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- `quote_id` / `quote_original_url` を本線にして quote を hydrate するように変更
- timeline sync の再試行でも `RE:` ベースのフォールバック解決を継続
- streaming 受信時の `Update` / `StatusUpdate` / notification 内 status でも quote を展開して保存・配信
- `RE:` 判定はフォールバックとして残し、`/notes/...` の quote URL も解決対象に追加

## Testing
- `bun run build`
- `cargo test services::timeline_service::tests::`