### PR TITLE
Allow media sources in Tauri CSP

### DIFF
--- a/tauri.conf.json
+++ b/tauri.conf.json
@@ -23,7 +23,7 @@
       }
     ],
     "security": {
-      "csp": "default-src 'self'; img-src 'self' asset: http: https: data: blob:; style-src 'self' 'unsafe-inline'; script-src 'self'; connect-src ipc: http: https: ws: wss:"
+      "csp": "default-src 'self'; img-src 'self' asset: http: https: data: blob:; media-src 'self' asset: http: https: data: blob:; style-src 'self' 'unsafe-inline'; script-src 'self'; connect-src ipc: http: https: ws: wss:"
     }
   },
   "bundle": {


### PR DESCRIPTION
## Summary
- Extend the Tauri Content Security Policy to allow `media-src` from `self`, `asset:`, `http:`, `https:`, `data:`, and `blob:`.
- Keeps existing `img-src`, `style-src`, `script-src`, and `connect-src` rules unchanged.

## Testing
- Not run (not requested)