### PR TITLE
Change Japanese follower label to 「被フォロー」

### DIFF
--- a/frontend/src/i18n.ts
+++ b/frontend/src/i18n.ts
@@ -117,7 +117,7 @@ const ja: Record<string, string> = {
   "Follow {subject}?": "{subject} をフォローしますか？",
   "Followers": "フォロワー",
   "Following": "フォロー中",
-  "Follows you": "フォローされています",
+  "Follows you": "被フォロー",
   Food: "食べ物",
   "Food & Drink": "食べ物と飲み物",
   "Font size": "フォントサイズ",


### PR DESCRIPTION
## Summary
- Update the Japanese translation for `Follows you` from `フォローされています` to `被フォロー`
- Align the label with the existing localized terminology used in the app

## Testing
- Not run (not requested)